### PR TITLE
fix: MCPサーバーのcapabilities API呼び出しを修正

### DIFF
--- a/src/mory/server.py
+++ b/src/mory/server.py
@@ -5,8 +5,10 @@ from typing import Any
 
 from mcp.server import Server
 from mcp.server.models import InitializationOptions
+
+# Removed incorrect imports - using default capabilities
 from mcp.server.stdio import stdio_server
-from mcp.types import Tool
+from mcp.types import ServerCapabilities, Tool, ToolsCapability
 
 from .memory import Memory, SearchQuery
 from .storage import JSONMemoryStore
@@ -248,14 +250,25 @@ class MoryServer:
         # Load existing data
         await self.store.load()
 
-        # Start the server
+        # Start the server with proper capabilities
         async with stdio_server() as (read_stream, write_stream):
+            # Define capabilities following MCP best practices
+            capabilities = ServerCapabilities(
+                tools=ToolsCapability(
+                    listChanged=False  # Set to True if tool list can change dynamically
+                ),
+                # Add other capabilities as needed:
+                # resources=ResourcesCapability(listChanged=False),
+                # prompts=PromptsCapability(listChanged=False),
+                # logging=LoggingCapability(),
+            )
+
             await self.server.run(
                 read_stream,
                 write_stream,
                 InitializationOptions(
                     server_name="mory-python",
                     server_version="0.1.0",
-                    capabilities=self.server.get_capabilities(),
+                    capabilities=capabilities,
                 ),
             )


### PR DESCRIPTION
## 概要
MCPライブラリの最新APIに対応し、サーバーの初期化とcapabilities設定を改善しました。

## 変更内容
- **MCPサーバーAPI修正**: `get_capabilities()`の複雑な引数要求を回避し、`ServerCapabilities`オブジェクトを直接作成
- **ベストプラクティス適用**: context7ドキュメントを参考にした適切な実装パターン
- **明示的なcapabilities設定**: `ToolsCapability(listChanged=False)`で明確にツール機能を有効化
- **将来の拡張性**: resources、prompts、loggingなどの追加機能用コメント
- **コード品質向上**: ruffによるインポート整理とフォーマット修正

## テスト計画
- [x] MCPサーバーの正常起動確認
- [x] 5つのMCPツール（save_memory、get_memory、list_memories、search_memories、delete_memory）の動作確認
- [x] `make quality`による品質チェック通過
- [x] Claude Desktopとの通信待機状態確認

## 技術詳細
MCPライブラリのAPI変更により`get_capabilities()`メソッドが`notification_options`と`experimental_capabilities`の引数を必要とするようになったため、代わりに`ServerCapabilities`オブジェクトを直接作成する方式に変更。これによりより明確で保守性の高い実装となりました。

🤖 Generated with [Claude Code](https://claude.ai/code)