### PR TITLE
fix: MCPサーバーをHTTPクライアント方式に修正

### DIFF
--- a/mory-server/start_mcp.sh
+++ b/mory-server/start_mcp.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "/Users/yast/git/mory/mory-server"
+exec /Users/yast/.local/bin/uv run python mcp_main.py


### PR DESCRIPTION
## 概要
MCPサーバーのアーキテクチャを修正し、直接データベースアクセスからHTTPクライアント方式に変更しました。

## 問題の解決
- **Issue**: MCPサーバーが直接SQLAlchemyでDBアクセスしていた
- **解決**: FastAPIサーバー(port 8080)へのHTTPリクエスト経由に変更
- **結果**: 正しいマイクロサービスアーキテクチャの実現

## アーキテクチャ変更

### Before
```
Claude Desktop → MCP Server → Direct DB Access
```

### After  
```
Claude Desktop → MCP Server → HTTP API → FastAPI Server → Database
```

## 実装変更

### 🔧 MCPサーバー修正
- **`app/mcp_server.py`**: 完全にHTTPクライアント実装に書き換え
- **依存関係変更**: SQLAlchemy → httpx AsyncClient
- **4つのMCPツール**: 全てHTTP API経由に変更
  - `save_memory` → `POST /api/memories`
  - `get_memory` → `GET /api/memories/{key}`
  - `list_memories` → `GET /api/memories`
  - `search_memories` → `POST /api/memories/search`

### 📁 新規ファイル
- **`start_mcp.sh`**: Claude Desktop用ラッパースクリプト

### ⚙️ Claude Desktop設定
```json
{
  "mcpServers": {
    "mory": {
      "command": "/path/to/start_mcp.sh",
      "env": {
        "MORY_API_URL": "http://localhost:8080"
      }
    }
  }
}
```

## テスト結果
✅ 全コード品質チェック合格  
✅ MCPサーバー起動テスト完了  
✅ HTTP API接続確認済み  

## デプロイ手順
1. FastAPI サーバー起動 (Docker, port 8080)
2. Claude Desktop 再起動でMCP設定読み込み
3. 新しい会話でMCPツール利用可能

🤖 Generated with [Claude Code](https://claude.ai/code)